### PR TITLE
Transition of homebridge-syno-spk from ozone to homebridge and refresh of build.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,6 @@ on:
         description: 'Version / Tag (x.x.x):'     
         required: true
 
-permissions:
-  id-token: write
-  contents: read
-  issues: write
-  pull-requests: write
-  
 jobs:
   release:
     name: Create Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,12 @@ on:
         description: 'Version / Tag (x.x.x):'     
         required: true
 
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+  pull-requests: write
+  
 jobs:
   release:
     name: Create Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,15 +172,12 @@ jobs:
         node index.js
 
     - name: Upload synology-spk-repo.json
-      id: uploadsynology-spk-repo-json 
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      id: upload-synology-spk-repo-json 
+      uses: AButler/upload-release-assets@v2.0
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: repo/spks/synology-spk-repo.json
-        asset_name: synology-spk-repo.json
-        asset_content_type: application/json
+        files: repo/spks/synology-spk-repo.json
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        release-tag: ${{ github.event.inputs.version }}
 
     - name: Upload Repo JSON to S3
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
             NODE_ARCH: x64
           - SPK_PLATFORM: evansport
             SPK_ARCH: i686
-            NODE_ARCH: x86
+            NODE_ARCH: x64
           - SPK_PLATFORM: rtd1296
             SPK_ARCH: armv8
             NODE_ARCH: arm64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,6 +171,17 @@ jobs:
         cd repo
         node index.js
 
+    - name: Upload synology-spk-repo.json
+      id: uploadsynology-spk-repo-json 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: repo/spks/synology-spk-repo.json
+        asset_name: synology-spk-repo.json
+        asset_content_type: application/json
+
     - name: Upload Repo JSON to S3
       run: |
         cat repo/spks/synology-spk-repo.json | jq

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,15 +70,15 @@ jobs:
 
             ### Recommended Post-Install Steps:
 
-            * [Enable compiling native modules](https://github.com/oznu/homebridge-syno-spk/wiki/DSM-7:-Enable-Compiling-Of-Native-Modules)
-            * [Install ffmpeg with libfdk_aac](https://github.com/oznu/homebridge-syno-spk/wiki/DSM-7:-ffmpeg-with-libfdk_aac)
-            * [Install git](https://github.com/oznu/homebridge-syno-spk/wiki/DSM-7:-Install-git)
+            * [Enable compiling native modules](https://github.com/homebridge/homebridge-syno-spk/wiki/DSM-7:-Enable-Compiling-Of-Native-Modules)
+            * [Install ffmpeg with libfdk_aac](https://github.com/homebridge/homebridge-syno-spk/wiki/DSM-7:-ffmpeg-with-libfdk_aac)
+            * [Install git](https://github.com/homebridge/homebridge-syno-spk/wiki/DSM-7:-Install-git)
 
             ---
 
             <span align="center">
 
-            *If you like the [Homebridge UI](https://github.com/oznu/homebridge-config-ui-x) or the [Homebridge Synology Package Installer](https://github.com/oznu/homebridge-syno-spk) please consider [donating via PayPal](https://paypal.me/oznu) ❤️*
+            *If you like the [Homebridge UI](https://github.com/homebridge/homebridge-config-ui-x) or the [Homebridge Synology Package Installer](https://github.com/homebridge/homebridge-syno-spk) please consider [donating via PayPal](https://paypal.me/oznu) ❤️*
 
             </span>
 

--- a/INFO.sh
+++ b/INFO.sh
@@ -6,12 +6,12 @@ package="homebridge"
 
 version=${SPK_PACKAGE_VERSION:-1.0.0}
 os_min_ver="7.0-40761"
-maintainer="oznu"
+maintainer="homebridge"
 thirdparty="yes"
 arch="${SPK_ARCH:-x86_64}"
 reloadui="yes"
 dsmuidir="ui"
-dsmappname="oznu.homebridge"
+dsmappname="homebridge.homebridge"
 silent_install="no"
 silent_upgrade="no"
 adminprotocol="http"
@@ -20,8 +20,8 @@ adminport="8581"
 
 displayname="Homebridge"
 description="Homebridge on Synology DSM."
-maintainer_url="https://github.com/oznu/homebridge-syno-spk"
-support_url="https://github.com/oznu/homebridge-syno-spk"
+maintainer_url="https://github.com/homebridge/homebridge-syno-spk"
+support_url="https://github.com/homebridge/homebridge-syno-spk"
 
 [ "$(caller)" != "0 NULL" ] && return 0
 pkg_dump_info

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 <img width="400px" src="https://user-images.githubusercontent.com/3979615/79035227-bdd5be00-7bff-11ea-900f-2fef01bba4ba.png">
 </p>
 
-[![GitHub release](https://img.shields.io/github/release/oznu/homebridge-syno-spk.svg)](https://github.com/oznu/homebridge-syno-spk/releases/latest)
-[![Build](https://github.com/oznu/homebridge-syno-spk/workflows/Build/badge.svg)](https://github.com/oznu/homebridge-syno-spk/actions)
+[![GitHub release](https://img.shields.io/github/release/homebridge/homebridge-syno-spk.svg)](https://github.com/homebridge/homebridge-syno-spk/releases/latest)
+[![Build](https://github.com/homebridge/homebridge-syno-spk/workflows/Build/badge.svg)](https://github.com/homebridge/homebridge-syno-spk/actions)
 [![Donate](https://badgen.net/badge/donate/paypal/yellow)](https://paypal.me/oznu)
 
 # Homebridge Package for Synology DSM
@@ -49,15 +49,15 @@ If you have the Synology Firewall enabled, make a rule to allow access to port 8
 
 ### Recommended Optional Steps:
 
-* [Enable compiling native modules](https://github.com/oznu/homebridge-syno-spk/wiki/DSM-7:-Enable-Compiling-Of-Native-Modules)
-* [Install ffmpeg with libfdk_aac](https://github.com/oznu/homebridge-syno-spk/wiki/DSM-7:-ffmpeg-with-libfdk_aac)
-* [Install git](https://github.com/oznu/homebridge-syno-spk/wiki/DSM-7:-Install-git)
+* [Enable compiling native modules](https://github.com/homebridge/homebridge-syno-spk/wiki/DSM-7:-Enable-Compiling-Of-Native-Modules)
+* [Install ffmpeg with libfdk_aac](https://github.com/homebridge/homebridge-syno-spk/wiki/DSM-7:-ffmpeg-with-libfdk_aac)
+* [Install git](https://github.com/homebridge/homebridge-syno-spk/wiki/DSM-7:-Install-git)
 
 ## Issues
 
 If you have an issue with the installation of Homebridge using this package please raise an issue on this project's GitHub page. For everything else:
 
-* Homebridge UI Issues: [oznu/homebridge-config-ui-x](https://github.com/oznu/homebridge-config-ui-x)
+* Homebridge UI Issues: [homebridge/homebridge-config-ui-x](https://github.com/homebridge/homebridge-config-ui-x)
 * General Homebridge Issues: [nfarina/homebridge](https://github.com/nfarina/homebridge)
 * For problems with individual plugins please raise issues on the relevant GitHub project page.
 

--- a/repo/index.js
+++ b/repo/index.js
@@ -35,12 +35,12 @@ const path = require('path');
       price: 0,
       download_count: 56691,
       recent_download_count: 1138,
-      link: `https://github.com/oznu/homebridge-syno-spk/releases/download/${version}/${spk}`,
+      link: `https://github.com/homebridge/homebridge-syno-spk/releases/download/${version}/${spk}`,
       size: fileStat.size,
       md5: md5sum,
       thumbnail: [
-       'https://raw.githubusercontent.com/oznu/homebridge-syno-spk/master/PACKAGE_ICON.PNG',
-       'https://raw.githubusercontent.com/oznu/homebridge-syno-spk/master/PACKAGE_ICON_256.PNG'
+       'https://raw.githubusercontent.com/homebridge/homebridge-syno-spk/master/PACKAGE_ICON.PNG',
+       'https://raw.githubusercontent.com/homebridge/homebridge-syno-spk/master/PACKAGE_ICON_256.PNG'
       ],
       snapshot: [],
       qinst: true,
@@ -50,8 +50,8 @@ const path = require('path');
       deppkgs: null,
       conflictpkgs: null,
       start: true,
-      maintainer: 'oznu',
-      maintainer_url: 'https://github.com/oznu/homebridge-syno-spk',
+      maintainer: 'homebridge',
+      maintainer_url: 'https://github.com/homebridge/homebridge-syno-spk',
       distributor: '',
       distributor_url: '',
       support_url: '',

--- a/ui/config
+++ b/ui/config
@@ -1,6 +1,6 @@
 {
     ".url": {
-        "oznu.homebridge": {
+        "homebridge.homebridge": {
             "title": "Homebridge",
             "desc": "Homebridge UI",
             "icon": "images/icon_256.png",


### PR DESCRIPTION
## :gear: Release Notes

* Transition of homebridge-syno-spk from ozone to homebridge
* Refresh of included packages to latest version
** NodeJS 18.16.1
** Homebridge 1.6.1
** Homebridge-config-ui-x 4.50.4